### PR TITLE
Support DBT 0.14.x

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,8 @@
 
 name: 'pageup_dbt_utils'
-version: '0.1'
+version: '3.0.0'
+
+require-dbt-version: ">=0.14.0"
 
 profile: 'default'
 

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,4 +1,4 @@
 packages:
     - local: ../
-    - git: "https://github.com/fishtown-analytics/dbt-utils.git"
-      revision: 0.1.22
+    - package: "fishtown-analytics/dbt_utils"
+      version: ">0.2.0"

--- a/macros/materializations/timestamp_incremental.sql
+++ b/macros/materializations/timestamp_incremental.sql
@@ -76,7 +76,7 @@
 
      {%- endcall -%}
 
-     {{ adapter.expand_target_column_types(temp_table=tmp_identifier, to_relation=target_relation) }}
+     {{ adapter.expand_target_column_types(from_relation=tmp_relation, to_relation=target_relation) }}
 
      {%- call statement('main') -%}
        {% set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') %}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-    - git: "https://github.com/fishtown-analytics/dbt-utils.git"
-      revision: 0.1.22
+    - package: "fishtown-analytics/dbt_utils"
+      version: ">0.2.0"


### PR DESCRIPTION
* Now requires dbt >=0.14.0
* Updated dbt utils to 0.2.x
* Updated dbt utils dependencies to use [dbtHub package](https://hub.getdbt.com/fishtown-analytics/dbt_utils/latest/)
* Changes to `timestamp_incremental` to maintain compatibility