### PR TITLE
[SP-299] Redshift Compatibility

### DIFF
--- a/macros/audit_logging/audit_schema.sql
+++ b/macros/audit_logging/audit_schema.sql
@@ -1,3 +1,3 @@
 {% macro create_audit_schema() %}
-    CREATE SCHEMA IF NOT EXISTS dbt;
+    {% do adapter.create_schema(target.database, "dbt") %}
 {% endmacro %}

--- a/macros/audit_logging/audit_schema.sql
+++ b/macros/audit_logging/audit_schema.sql
@@ -1,4 +1,3 @@
 {% macro create_audit_schema() %}
-    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
     {% do adapter.create_schema(target.database, "dbt") %};
 {% endmacro %}

--- a/macros/audit_logging/audit_schema.sql
+++ b/macros/audit_logging/audit_schema.sql
@@ -1,3 +1,3 @@
 {% macro create_audit_schema() %}
-    {% do adapter.create_schema(target.database, "dbt") %};
+    CREATE SCHEMA IF NOT EXISTS dbt;
 {% endmacro %}

--- a/macros/audit_logging/execution.sql
+++ b/macros/audit_logging/execution.sql
@@ -48,15 +48,9 @@
 
 {% macro log_execution_end_event() %}
     UPDATE {{ pageup_dbt_utils.get_execution_relation() }}
-    SET (
-        last_updated_on,
-        status
-        )
-    = (
-        {{dbt_utils.current_timestamp_in_utc()}},
-        'completed'
-        )
+    SET last_updated_on={{dbt_utils.current_timestamp_in_utc()}}, status='completed'
     WHERE execution_id='{{ invocation_id }}'::text;
+    
     {% for result in results -%}
         {{ pageup_dbt_utils.log_execution_model_event(result) }};
     {% endfor %}

--- a/macros/audit_logging/execution.sql
+++ b/macros/audit_logging/execution.sql
@@ -19,7 +19,7 @@
 
     create table if not exists {{ pageup_dbt_utils.get_execution_relation() }}
     (
-        execution_id        uuid PRIMARY KEY NOT NULL,
+        execution_id        varchar(250) PRIMARY KEY NOT NULL,
         created_on          {{dbt_utils.type_timestamp()}} NOT NULL DEFAULT current_timestamp,
         last_updated_on     {{dbt_utils.type_timestamp()}} NOT NULL,
         is_full_refresh     boolean NOT NULL,
@@ -38,7 +38,7 @@
         )
 
     values (
-        '{{ invocation_id }}'::uuid,
+        '{{ invocation_id }}'::text,
         {{dbt_utils.current_timestamp_in_utc()}},
         {{ flags.FULL_REFRESH }},
         'started'
@@ -56,7 +56,7 @@
         {{dbt_utils.current_timestamp_in_utc()}},
         'completed'
         )
-    WHERE execution_id='{{ invocation_id }}'::uuid;
+    WHERE execution_id='{{ invocation_id }}'::text;
     {% for result in results -%}
         {{ pageup_dbt_utils.log_execution_model_event(result) }};
     {% endfor %}

--- a/macros/audit_logging/execution_model.sql
+++ b/macros/audit_logging/execution_model.sql
@@ -11,6 +11,7 @@
 {% macro log_execution_model_event(result) %}
 
     insert into {{ pageup_dbt_utils.get_execution_model_relation() }} (
+        execution_model_id,
         execution_id,
         last_updated_on,
         status,
@@ -23,6 +24,7 @@
         )
 
     values (
+        '{{ fn_uuid() }}'::text
         '{{ invocation_id }}'::text,
         {{dbt_utils.current_timestamp_in_utc()}},
         {% if variable != None %}'{{ result.status }}'{% else %} 'ERROR UNKNOWN' {% endif %},

--- a/macros/audit_logging/execution_model.sql
+++ b/macros/audit_logging/execution_model.sql
@@ -24,7 +24,7 @@
         )
 
     values (
-        fn_uuid()::text
+        fn_uuid()::text,
         '{{ invocation_id }}'::text,
         {{dbt_utils.current_timestamp_in_utc()}},
         {% if variable != None %}'{{ result.status }}'{% else %} 'ERROR UNKNOWN' {% endif %},

--- a/macros/audit_logging/execution_model.sql
+++ b/macros/audit_logging/execution_model.sql
@@ -23,7 +23,7 @@
         )
 
     values (
-        '{{ invocation_id }}'::uuid,
+        '{{ invocation_id }}'::text,
         {{dbt_utils.current_timestamp_in_utc()}},
         {% if variable != None %}'{{ result.status }}'{% else %} 'ERROR UNKNOWN' {% endif %},
         '{{ result.node.schema }}',
@@ -41,9 +41,9 @@
 
     create table if not exists {{ pageup_dbt_utils.get_execution_model_relation() }}
     (
-        execution_model_id  uuid PRIMARY KEY NOT NULL DEFAULT uuid_generate_v1(),
+        execution_model_id  varchar(250) PRIMARY KEY NOT NULL,
         created_on          {{dbt_utils.type_timestamp()}} NOT NULL DEFAULT current_timestamp,
-        execution_id        uuid NOT NULL,
+        execution_id        varchar(250) NOT NULL,
         last_updated_on     {{dbt_utils.type_timestamp()}} NOT NULL,
         status              varchar(512) NOT NULL,
         model_schema        varchar(512) NOT NULL,

--- a/macros/audit_logging/execution_model.sql
+++ b/macros/audit_logging/execution_model.sql
@@ -24,7 +24,7 @@
         )
 
     values (
-        '{{ fn_uuid() }}'::text
+        fn_uuid()::text
         '{{ invocation_id }}'::text,
         {{dbt_utils.current_timestamp_in_utc()}},
         {% if variable != None %}'{{ result.status }}'{% else %} 'ERROR UNKNOWN' {% endif %},


### PR DESCRIPTION
# SP-299
### Changes
- Remove creation of extension `uuid-ossp` when creating the audit schema
- Replace `uuid` data types with `varchar(250)` (similar to RDL)
- Invoke UDF `fn_uuid()` when inserting execution model data
    - UUID generated for `execution_model_id`
- Update `SET` statement for `execution` model