### PR TITLE
delete old backups during timestamp_incremental

### DIFF
--- a/macros/materializations/timestamp_incremental.sql
+++ b/macros/materializations/timestamp_incremental.sql
@@ -24,10 +24,6 @@
   {% set existing_relation = load_relation(this) %}
   {% set tmp_relation = make_temp_relation(this) %}
 
-  {# -- set the type so our rename / drop uses the correct syntax #}
-  {% set backup_type = existing_relation.type | default("table") %}
-  {% set backup_relation = make_temp_relation(this, "__dbt_backup").incorporate(type=backup_type) %}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:
@@ -37,6 +33,11 @@
   {% if existing_relation is none %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
   {% elif existing_relation.is_view or full_refresh_mode %}
+      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
+      {% set backup_identifier = existing_relation.identifier ~ "__dbt_backup" %}
+      {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
+      {% do adapter.drop_relation(backup_relation) %}
+
       {% do adapter.rename_relation(target_relation, backup_relation) %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
       {% do to_drop.append(backup_relation) %}
@@ -62,7 +63,7 @@
   {% do adapter.commit() %}
 
   {% for rel in to_drop %}
-      {% do drop_relation(rel) %}
+      {% do adapter.drop_relation(rel) %}
   {% endfor %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}


### PR DESCRIPTION
logic copied from changes in default dbt incremental materialization, looks like this was added after 0.15.0rc1.