### PR TITLE
Support dbt 0.18

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: "pageup_dbt_utils"
 version: "3.0.0"
 config-version: 2
 
-require-dbt-version: ">=0.15.0"
+require-dbt-version: ">=0.18.0"
 
 profile: "default"
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,10 +1,10 @@
-
-name: 'pageup_dbt_utils'
-version: '3.0.0'
+name: "pageup_dbt_utils"
+version: "3.0.0"
+config-version: 2
 
 require-dbt-version: ">=0.15.0"
 
-profile: 'default'
+profile: "default"
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]
@@ -12,8 +12,8 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-target-path: "target"  # directory which will store compiled SQL files
-clean-targets:         # directories to be removed by `dbt clean`
+target-path: "target" # directory which will store compiled SQL files
+clean-targets: # directories to be removed by `dbt clean`
     - "target"
     - "dbt_modules"
 

--- a/macros/audit_logging/audit_schema.sql
+++ b/macros/audit_logging/audit_schema.sql
@@ -1,4 +1,4 @@
 {% macro create_audit_schema() %}
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-    {% do adapter.create_schema(target.database, "dbt") %};
+    {% do adapter.create_schema(api.Relation.create(database=target.database, schema="dbt")) %};
 {% endmacro %}

--- a/macros/audit_logging/execution.sql
+++ b/macros/audit_logging/execution.sql
@@ -40,7 +40,7 @@
     values (
         '{{ invocation_id }}'::uuid,
         {{dbt_utils.current_timestamp_in_utc()}},
-        {{ flags.should_full_refresh() }},
+        {{ should_full_refresh() }},
         'started'
         )
 {% endmacro %}

--- a/macros/audit_logging/execution.sql
+++ b/macros/audit_logging/execution.sql
@@ -40,7 +40,7 @@
     values (
         '{{ invocation_id }}'::uuid,
         {{dbt_utils.current_timestamp_in_utc()}},
-        {{ flags.FULL_REFRESH }},
+        {{ flags.should_full_refresh() }},
         'started'
         )
 {% endmacro %}


### PR DESCRIPTION
Bumping minimum version to 0.18

- support config-version 2
- audit logging uses `should_full_refresh()`
- timestamp_incremental updated, supports persisting docs